### PR TITLE
제보 검색 기능 구현

### DIFF
--- a/src/main/java/org/bf/reportservice/application/query/ReportQueryService.java
+++ b/src/main/java/org/bf/reportservice/application/query/ReportQueryService.java
@@ -1,6 +1,8 @@
 package org.bf.reportservice.application.query;
 
 import org.bf.reportservice.presentation.dto.ReportDetailResponse;
+import org.bf.reportservice.presentation.dto.ReportSearchRequest;
+import org.bf.reportservice.presentation.dto.ReportSearchResponse;
 import org.bf.reportservice.presentation.dto.ReportSummaryResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -10,4 +12,5 @@ import java.util.UUID;
 public interface ReportQueryService {
     Page<ReportSummaryResponse> getReports(Pageable pageable);
     ReportDetailResponse getReport(UUID reportId);
+    Page<ReportSearchResponse> searchReports(ReportSearchRequest request, Pageable pageable);
 }

--- a/src/main/java/org/bf/reportservice/application/query/ReportQueryServiceImpl.java
+++ b/src/main/java/org/bf/reportservice/application/query/ReportQueryServiceImpl.java
@@ -1,11 +1,12 @@
-package org.bf.reportservice.application.query.impl;
+package org.bf.reportservice.application.query;
 
 import lombok.RequiredArgsConstructor;
 import org.bf.global.infrastructure.exception.CustomException;
-import org.bf.reportservice.application.query.ReportQueryService;
 import org.bf.reportservice.domain.exception.ReportErrorCode;
 import org.bf.reportservice.infrastructure.persistence.ReportQueryRepository;
 import org.bf.reportservice.presentation.dto.ReportDetailResponse;
+import org.bf.reportservice.presentation.dto.ReportSearchRequest;
+import org.bf.reportservice.presentation.dto.ReportSearchResponse;
 import org.bf.reportservice.presentation.dto.ReportSummaryResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -30,5 +31,10 @@ public class ReportQueryServiceImpl implements ReportQueryService {
     public ReportDetailResponse getReport(UUID reportId) {
         return reportQueryRepository.findReportDetail(reportId)
                 .orElseThrow(() -> new CustomException(ReportErrorCode.REPORT_NOT_FOUND));
+    }
+
+    @Override
+    public Page<ReportSearchResponse> searchReports(ReportSearchRequest request, Pageable pageable) {
+        return reportQueryRepository.searchReports(request, pageable);
     }
 }

--- a/src/main/java/org/bf/reportservice/infrastructure/persistence/ReportQueryRepository.java
+++ b/src/main/java/org/bf/reportservice/infrastructure/persistence/ReportQueryRepository.java
@@ -1,6 +1,8 @@
 package org.bf.reportservice.infrastructure.persistence;
 
 import org.bf.reportservice.presentation.dto.ReportDetailResponse;
+import org.bf.reportservice.presentation.dto.ReportSearchRequest;
+import org.bf.reportservice.presentation.dto.ReportSearchResponse;
 import org.bf.reportservice.presentation.dto.ReportSummaryResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,4 +13,5 @@ import java.util.UUID;
 public interface ReportQueryRepository {
     Page<ReportSummaryResponse> findReports(Pageable pageable);
     Optional<ReportDetailResponse> findReportDetail(UUID reportId);
+    Page<ReportSearchResponse> searchReports(ReportSearchRequest request, Pageable pageable);
 }

--- a/src/main/java/org/bf/reportservice/infrastructure/persistence/ReportQueryRepositoryImpl.java
+++ b/src/main/java/org/bf/reportservice/infrastructure/persistence/ReportQueryRepositoryImpl.java
@@ -4,12 +4,16 @@ import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.bf.reportservice.domain.entity.ImageTag;
 import org.bf.reportservice.domain.entity.QReport;
 import org.bf.reportservice.domain.entity.QReportImage;
 import org.bf.reportservice.domain.entity.ReportStatus;
 import org.bf.reportservice.presentation.dto.ReportDetailResponse;
+import org.bf.reportservice.presentation.dto.ReportSearchRequest;
+import org.bf.reportservice.presentation.dto.ReportSearchResponse;
 import org.bf.reportservice.presentation.dto.ReportSummaryResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -17,6 +21,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -33,6 +38,7 @@ public class ReportQueryRepositoryImpl implements ReportQueryRepository {
 
     @Override
     public Page<ReportSummaryResponse> findReports(Pageable pageable) {
+        // 삭제된 제보글 제외한 목록 조회
         List<OrderSpecifier<?>> orders = toOrderSpecifiers(pageable.getSort());
 
         List<ReportSummaryResponse> content = queryFactory
@@ -62,7 +68,7 @@ public class ReportQueryRepositoryImpl implements ReportQueryRepository {
     @Override
     public Optional<ReportDetailResponse> findReportDetail(UUID reportId) {
 
-        // report 기본 필드 먼저 조회 (images 제외)
+        // 제보 기본 필드 먼저 조회 (images 제외)
         Tuple base = queryFactory
                 .select(
                         report.id,
@@ -111,6 +117,50 @@ public class ReportQueryRepositoryImpl implements ReportQueryRepository {
         return Optional.of(response);
     }
 
+    /**
+     * 제보글 검색
+     * - 삭제된 제보글 제외
+     * - keyword(title/content), tag, 기간 조건 적용
+     */
+    @Override
+    public Page<ReportSearchResponse> searchReports(ReportSearchRequest request, Pageable pageable) {
+
+        List<ReportSearchResponse> content = queryFactory
+                .select(Projections.constructor(
+                        ReportSearchResponse.class,
+                        report.id,
+                        report.title,
+                        report.tag,
+                        report.createdAt
+                ))
+                .from(report)
+                .where(
+                        report.reportStatus.ne(ReportStatus.DELETED),
+                        keywordContains(request.keyword()),
+                        tagEq(request.tag()),
+                        createdAfter(request.from()),
+                        createdBefore(request.to())
+                )
+                .orderBy(report.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(report.count())
+                .from(report)
+                .where(
+                        report.reportStatus.ne(ReportStatus.DELETED),
+                        keywordContains(request.keyword()),
+                        tagEq(request.tag()),
+                        createdAfter(request.from()),
+                        createdBefore(request.to())
+                )
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total == null ? 0 : total);
+    }
+
     private List<OrderSpecifier<?>> toOrderSpecifiers(Sort sort) {
         if (sort == null || sort.isUnsorted()) {
             return List.of(new OrderSpecifier<>(Order.DESC, report.createdAt));
@@ -128,4 +178,23 @@ public class ReportQueryRepositoryImpl implements ReportQueryRepository {
         }
         return list;
     }
+
+    private BooleanExpression keywordContains(String keyword) {
+        if (keyword == null || keyword.isBlank()) return null;
+        return report.title.containsIgnoreCase(keyword)
+                .or(report.content.containsIgnoreCase(keyword));
+    }
+
+    private BooleanExpression tagEq(ImageTag tag) {
+        return tag == null ? null : report.tag.eq(tag);
+    }
+
+    private BooleanExpression createdAfter(LocalDateTime from) {
+        return from == null ? null : report.createdAt.goe(from);
+    }
+
+    private BooleanExpression createdBefore(LocalDateTime to) {
+        return to == null ? null : report.createdAt.loe(to);
+    }
+
 }

--- a/src/main/java/org/bf/reportservice/presentation/controller/ReportController.java
+++ b/src/main/java/org/bf/reportservice/presentation/controller/ReportController.java
@@ -66,8 +66,16 @@ public class ReportController {
     /**
      * 제보글 상세 조회
      */
-    @GetMapping("/{reportId}")
+    @GetMapping("/detail/{reportId}")
     public CustomResponse<ReportDetailResponse> getReport(@PathVariable UUID reportId) {
         return CustomResponse.onSuccess(GeneralSuccessCode.OK, reportQueryService.getReport(reportId));
+    }
+
+    /**
+     * 제보글 검색
+     */
+    @GetMapping("/search")
+    public CustomResponse<Page<ReportSearchResponse>> searchReports(@ModelAttribute ReportSearchRequest request, Pageable pageable) {
+        return CustomResponse.onSuccess(GeneralSuccessCode.OK, reportQueryService.searchReports(request, pageable));
     }
 }

--- a/src/main/java/org/bf/reportservice/presentation/dto/ReportSearchRequest.java
+++ b/src/main/java/org/bf/reportservice/presentation/dto/ReportSearchRequest.java
@@ -1,0 +1,12 @@
+package org.bf.reportservice.presentation.dto;
+
+import org.bf.reportservice.domain.entity.ImageTag;
+
+import java.time.LocalDateTime;
+
+public record ReportSearchRequest(
+        String keyword,
+        ImageTag tag,
+        LocalDateTime from,
+        LocalDateTime to
+) {}

--- a/src/main/java/org/bf/reportservice/presentation/dto/ReportSearchResponse.java
+++ b/src/main/java/org/bf/reportservice/presentation/dto/ReportSearchResponse.java
@@ -1,0 +1,13 @@
+package org.bf.reportservice.presentation.dto;
+
+import org.bf.reportservice.domain.entity.ImageTag;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record ReportSearchResponse(
+        UUID reportId,
+        String title,
+        ImageTag tag,
+        LocalDateTime createdAt
+) {}


### PR DESCRIPTION
- 제목 : feat(#6): 제보 검색 기능 구현

## 🔘Part

- ReportQueryRepository
- ReportQueryRepositoryImpl
- ReportSearchRequest
- ReportSearchResponse
- ReportQueryService
- ReportQueryServiceImpl
- ReportController

## 🔎 작업 내용

- ReportQueryRepository: 제보 검색을 위한 searchReports 인터페이스 추가
- ReportQueryRepositoryImpl: QueryDSL 기반 제보 검색 쿼리 구현
- ReportSearchRequest: 제보 검색 조건(keyword, tag, 기간) 요청 DTO 추가
- ReportSearchResponse: 제보 검색 결과 목록 응답 DTO 추가
- ReportQueryService: 제보 검색 서비스 메서드 시그니처 추가
- ReportQueryServiceImpl: 제보 검색 서비스 로직 구현
- ReportController: 제보 검색 API 추가 및 상세 조회 API 수정

## 🔧 점검 내용

- 관리자가 유의해서 확인해야할 내용이
- 있다면 적어주세요

## ➕ 이슈 링크

- [#6]