### PR TITLE
제보 등록 비동기 처리 적용

### DIFF
--- a/src/main/java/org/bf/reportservice/application/command/AsyncReportService.java
+++ b/src/main/java/org/bf/reportservice/application/command/AsyncReportService.java
@@ -1,0 +1,63 @@
+package org.bf.reportservice.application.command;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.bf.global.infrastructure.exception.CustomException;
+import org.bf.reportservice.application.event.AiVerificationEventPublisher;
+import org.bf.reportservice.domain.entity.Report;
+import org.bf.reportservice.domain.exception.ReportErrorCode;
+import org.bf.reportservice.domain.repository.ReportRepository;
+import org.bf.reportservice.presentation.dto.ReportResponse;
+import org.bf.reportservice.presentation.dto.async.AsyncReportCreateRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AsyncReportService {
+
+    private final ReportRepository reportRepository;
+    private final AiVerificationEventPublisher aiVerificationEventPublisher;
+
+    /**
+     * 비동기 제보 등록
+     * - 제보 기본 정보만 먼저 저장 (PENDING)
+     * - AI 검증 요청 이벤트 발행
+     * - 검증 결과 반영은 별도 리스너에서 처리
+     */
+    @Transactional
+    public ReportResponse createReport(AsyncReportCreateRequest request, UUID userId) {
+
+        if (request == null || request.images() == null || request.images().isEmpty()) {
+            throw new CustomException(ReportErrorCode.IMAGE_REQUIRED);
+        }
+
+        // 검증 전 -> tag는 null 상태로 저장
+        Report report = Report.builder()
+                .userId(userId)
+                .title(request.title())
+                .content(request.content())
+                .tag(null)
+                .build();
+
+        reportRepository.save(report);
+
+        // AI 검증 요청 이벤트 발행
+        aiVerificationEventPublisher.publishRequested(report.getId(), request);
+
+        return ReportResponse.from(report);
+    }
+
+    /**
+     * 비동기 등록된 제보 조회
+     */
+    @Transactional(readOnly = true)
+    public ReportResponse getReport(UUID reportId) {
+        Report report = reportRepository.findById(reportId)
+                .orElseThrow(() -> new CustomException(ReportErrorCode.REPORT_NOT_FOUND));
+        return ReportResponse.from(report);
+    }
+}

--- a/src/main/java/org/bf/reportservice/application/event/AiVerificationEventPublisher.java
+++ b/src/main/java/org/bf/reportservice/application/event/AiVerificationEventPublisher.java
@@ -1,0 +1,12 @@
+package org.bf.reportservice.application.event;
+
+import org.bf.reportservice.presentation.dto.async.AsyncReportCreateRequest;
+
+import java.util.UUID;
+
+public interface AiVerificationEventPublisher {
+    /**
+     * AI 이미지 검증 요청 이벤트 발행
+     */
+    void publishRequested(UUID reportId, AsyncReportCreateRequest request);
+}

--- a/src/main/java/org/bf/reportservice/application/event/impl/AiVerificationEventPublisherImpl.java
+++ b/src/main/java/org/bf/reportservice/application/event/impl/AiVerificationEventPublisherImpl.java
@@ -1,0 +1,58 @@
+package org.bf.reportservice.application.event.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.bf.global.domain.event.DomainEventBuilder;
+import org.bf.global.domain.event.EventPublisher;
+import org.bf.reportservice.application.event.AiVerificationEventPublisher;
+import org.bf.reportservice.infrastructure.event.AiImageMeta;
+import org.bf.reportservice.infrastructure.event.AiVerificationRequestedEvent;
+import org.bf.reportservice.presentation.dto.async.AsyncReportCreateRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.util.List;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class AiVerificationEventPublisherImpl implements AiVerificationEventPublisher {
+
+    private final EventPublisher eventPublisher;
+    private final DomainEventBuilder eventBuilder;
+
+    /**
+     * AI 이미지 검증 요청 이벤트 발행
+     */
+    @Override
+    public void publishRequested(UUID reportId, AsyncReportCreateRequest request) {
+
+        List<AiImageMeta> images = request.images().stream()
+                .map(i -> new AiImageMeta(i.fileUrl(), i.latitude(), i.longitude(), i.address()))
+                .toList();
+
+        // AI 검증 요청 이벤트 생성
+        AiVerificationRequestedEvent rawEvent = new AiVerificationRequestedEvent(
+                images,
+                reportId,
+                "p_report"
+        );
+
+        AiVerificationRequestedEvent event = eventBuilder.build(rawEvent);
+
+        // 트랜잭션 커밋 이후 이벤트 발행
+        if (TransactionSynchronizationManager.isActualTransactionActive()) {
+            TransactionSynchronizationManager.registerSynchronization(
+                    new TransactionSynchronization() {
+                        @Override
+                        public void afterCommit() {
+                            eventPublisher.publish(event);
+                        }
+                    }
+            );
+            return;
+        }
+        // 트랜잭션이 없는 경우 즉시 발행
+        eventPublisher.publish(event);
+    }
+}

--- a/src/main/java/org/bf/reportservice/domain/entity/Report.java
+++ b/src/main/java/org/bf/reportservice/domain/entity/Report.java
@@ -32,7 +32,6 @@ public class Report extends Auditable {
     private String content;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
     private ImageTag tag;
 
     @Enumerated(EnumType.STRING)
@@ -116,5 +115,12 @@ public class Report extends Auditable {
      */
     public void markPointRewarded() {
         this.isPointRewarded = true;
+    }
+
+    /**
+     * AI 검증 완료 이후 장애물 태그 반영
+     */
+    public void updateTag(ImageTag tag) {
+        this.tag = tag;
     }
 }

--- a/src/main/java/org/bf/reportservice/infrastructure/event/AiImageMeta.java
+++ b/src/main/java/org/bf/reportservice/infrastructure/event/AiImageMeta.java
@@ -1,0 +1,11 @@
+package org.bf.reportservice.infrastructure.event;
+
+/**
+ * AI 이미지 검증 요청에 사용되는 이미지 메타 정보
+ */
+public record AiImageMeta(
+        String fileUrl,
+        Double latitude,
+        Double longitude,
+        String address
+) {}

--- a/src/main/java/org/bf/reportservice/infrastructure/event/AiVerificationCompletedEvent.java
+++ b/src/main/java/org/bf/reportservice/infrastructure/event/AiVerificationCompletedEvent.java
@@ -1,0 +1,35 @@
+package org.bf.reportservice.infrastructure.event;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.bf.global.domain.event.AbstractDomainEvent;
+
+import java.util.UUID;
+
+/**
+ * AI 이미지 검증 결과 전달 이벤트
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AiVerificationCompletedEvent extends AbstractDomainEvent {
+
+    @JsonProperty("analysis_result")
+    private String analysisResult;
+
+    @JsonProperty("is_obstacle")
+    private boolean isObstacle;
+
+    private String tag;
+    private UUID sourceId;
+    private String sourceTable;
+
+    @Override
+    public String getTopicName() {
+        return "ai-verification-result";
+    }
+}

--- a/src/main/java/org/bf/reportservice/infrastructure/event/AiVerificationRequestedEvent.java
+++ b/src/main/java/org/bf/reportservice/infrastructure/event/AiVerificationRequestedEvent.java
@@ -1,0 +1,29 @@
+package org.bf.reportservice.infrastructure.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.bf.global.domain.event.AbstractDomainEvent;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * AI 이미지 검증 요청 이벤트
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AiVerificationRequestedEvent extends AbstractDomainEvent {
+
+    private List<AiImageMeta> images;
+    private UUID sourceId;
+    private String sourceTable;
+
+    @Override
+    public String getTopicName() {
+        return "ai-verification-request";
+    }
+}

--- a/src/main/java/org/bf/reportservice/infrastructure/exception/QueueFullException.java
+++ b/src/main/java/org/bf/reportservice/infrastructure/exception/QueueFullException.java
@@ -1,0 +1,7 @@
+package org.bf.reportservice.infrastructure.exception;
+
+public class QueueFullException extends RuntimeException {
+    public QueueFullException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/bf/reportservice/infrastructure/kafka/AiVerificationEventListener.java
+++ b/src/main/java/org/bf/reportservice/infrastructure/kafka/AiVerificationEventListener.java
@@ -1,0 +1,56 @@
+package org.bf.reportservice.infrastructure.kafka;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.bf.reportservice.domain.entity.ImageTag;
+import org.bf.reportservice.domain.entity.Report;
+import org.bf.reportservice.domain.entity.VerificationStatus;
+import org.bf.reportservice.domain.repository.ReportRepository;
+import org.bf.reportservice.infrastructure.event.AiVerificationCompletedEvent;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AiVerificationEventListener {
+
+    private final ReportRepository reportRepository;
+
+    /**
+     * AI 검증 완료 이벤트 수신
+     * - sourceId(reportId)로 제보 조회
+     * - 검증 상태가 PENDING인 경우에만 처리
+     * - 검증 실패 시 결과만 반영 (상태 변경은 도메인 로직에 위임)
+     * - 검증 성공 시 장애물 태그 설정 후 결과 반영
+     */
+    @KafkaListener(
+            topics = "ai-verification-result",
+            groupId = "report-service-group",
+            containerFactory = "genericKafkaListenerContainerFactory"
+    )
+    @Transactional
+    public void handle(AiVerificationCompletedEvent event) {
+
+        // 검증 대상 제보 조회
+        Report report = reportRepository.findById(event.getSourceId()).orElse(null);
+
+        if (report == null) return;
+
+        // 이미 검증이 끝난 제보인 경우 중복 처리 방지
+        if (report.getVerificationStatus() != VerificationStatus.PENDING) {
+            return;
+        }
+
+        // 장애물이 아닌 경우 태그 없이 검증 결과만 반영
+        if (!event.isObstacle()) {
+            report.updateVerificationResult(false, event.getAnalysisResult());
+            return;
+        }
+
+        // 장애물인 경우 태그 설정 후 검증 결과 반영
+        report.updateTag(ImageTag.from(event.getTag()));
+        report.updateVerificationResult(true, event.getAnalysisResult());
+    }
+}

--- a/src/main/java/org/bf/reportservice/infrastructure/persistence/impl/ReportQueryRepositoryImpl.java
+++ b/src/main/java/org/bf/reportservice/infrastructure/persistence/impl/ReportQueryRepositoryImpl.java
@@ -42,7 +42,7 @@ public class ReportQueryRepositoryImpl implements ReportQueryRepository {
      */
     @Override
     public Page<ReportSummaryResponse> findReports(Pageable pageable) {
-        // 삭제된 제보글 제외한 목록 조회
+        // AI 이미지 검증을 통과한 제보글 목록 조회
         List<OrderSpecifier<?>> orders = toOrderSpecifiers(pageable.getSort());
 
         List<ReportSummaryResponse> content = queryFactory
@@ -54,7 +54,7 @@ public class ReportQueryRepositoryImpl implements ReportQueryRepository {
                         report.createdAt
                 ))
                 .from(report)
-                .where(report.reportStatus.ne(ReportStatus.DELETED))
+                .where(report.reportStatus.eq(ReportStatus.APPROVED))
                 .orderBy(orders.toArray(new OrderSpecifier[0]))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -63,7 +63,7 @@ public class ReportQueryRepositoryImpl implements ReportQueryRepository {
         Long total = queryFactory
                 .select(report.id.count())
                 .from(report)
-                .where(report.reportStatus.ne(ReportStatus.DELETED))
+                .where(report.reportStatus.eq(ReportStatus.APPROVED))
                 .fetchOne();
 
         return new PageImpl<>(content, pageable, total == null ? 0 : total);
@@ -88,7 +88,7 @@ public class ReportQueryRepositoryImpl implements ReportQueryRepository {
                 .from(report)
                 .where(
                         report.id.eq(reportId),
-                        report.reportStatus.ne(ReportStatus.DELETED)
+                        report.reportStatus.eq(ReportStatus.APPROVED)
                 )
                 .fetchOne();
 
@@ -126,7 +126,7 @@ public class ReportQueryRepositoryImpl implements ReportQueryRepository {
 
     /**
      * 제보글 검색
-     * - 삭제된 제보글 제외
+     * - AI 이미지 검증을 통과한 제보글만 검색 대상 (APPROVED)
      * - keyword(title/content), tag, 기간 조건 적용
      */
     @Override
@@ -142,7 +142,7 @@ public class ReportQueryRepositoryImpl implements ReportQueryRepository {
                 ))
                 .from(report)
                 .where(
-                        report.reportStatus.ne(ReportStatus.DELETED),
+                        report.reportStatus.eq(ReportStatus.APPROVED),
                         keywordContains(request.keyword()),
                         tagEq(request.tag()),
                         createdAfter(request.from()),
@@ -157,7 +157,7 @@ public class ReportQueryRepositoryImpl implements ReportQueryRepository {
                 .select(report.count())
                 .from(report)
                 .where(
-                        report.reportStatus.ne(ReportStatus.DELETED),
+                        report.reportStatus.eq(ReportStatus.APPROVED),
                         keywordContains(request.keyword()),
                         tagEq(request.tag()),
                         createdAfter(request.from()),

--- a/src/main/java/org/bf/reportservice/presentation/controller/async/AsyncReportController.java
+++ b/src/main/java/org/bf/reportservice/presentation/controller/async/AsyncReportController.java
@@ -1,0 +1,39 @@
+package org.bf.reportservice.presentation.controller.async;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.bf.global.infrastructure.CustomResponse;
+import org.bf.global.infrastructure.success.GeneralSuccessCode;
+import org.bf.global.security.SecurityUtils;
+import org.bf.reportservice.application.command.AsyncReportService;
+import org.bf.reportservice.presentation.dto.ReportResponse;
+import org.bf.reportservice.presentation.dto.async.AsyncReportCreateRequest;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/async")
+@Tag(name = "Async Report API", description = "비동기 제보글 등록/조회 API")
+public class AsyncReportController {
+
+    private final AsyncReportService asyncReportService;
+    private final SecurityUtils securityUtils;
+
+    @Operation(summary = "비동기 제보글 등록")
+    @PostMapping
+    public CustomResponse<ReportResponse> createReport(@Valid @RequestBody AsyncReportCreateRequest request) {
+        ReportResponse response = asyncReportService.createReport(request, securityUtils.getCurrentUserId());
+        return CustomResponse.onSuccess(GeneralSuccessCode.CREATED, response);
+    }
+
+    @Operation(summary = "비동기 제보글 조회")
+    @GetMapping("/{reportId}")
+    public CustomResponse<ReportResponse> getReport(@PathVariable UUID reportId) {
+        ReportResponse response = asyncReportService.getReport(reportId);
+        return CustomResponse.onSuccess(GeneralSuccessCode.OK, response);
+    }
+}

--- a/src/main/java/org/bf/reportservice/presentation/dto/async/AsyncReportCreateRequest.java
+++ b/src/main/java/org/bf/reportservice/presentation/dto/async/AsyncReportCreateRequest.java
@@ -1,0 +1,19 @@
+package org.bf.reportservice.presentation.dto.async;
+
+import java.util.List;
+
+/**
+ * 비동기 제보 등록 요청 DTO
+ */
+public record AsyncReportCreateRequest(
+        String title,
+        String content,
+        List<ImageMeta> images
+) {
+    public record ImageMeta(
+            String fileUrl,
+            Double latitude,
+            Double longitude,
+            String address
+    ) {}
+}


### PR DESCRIPTION
- 제목 : feat(#31): 제보 등록 비동기 처리 적용

## 🔘Part

- AiImageMeta
- AiVerificationRequestedEvent / AiVerificationCompletedEvent
- AiVerificationEventPublisher / AiVerificationEventPublisherImpl
- AsyncReportCreateRequest
- AsyncReportService
- AsyncReportController
- Report
- AiVerificationEventListener
- ReportQueryRepositoryImpl
- QueueFullException

## 🔎 작업 내용

- AiImageMeta: AI 검증 요청에 전달할 이미지 메타 DTO 추가
- AiVerificationRequestedEvent: AI 검증 요청용 Kafka 이벤트 정의
- AiVerificationEventPublisher: AI 검증 요청 발행 인터페이스 추가
- AiVerificationEventPublisherImpl: AI 검증 요청 이벤트 발행 구현체 추가
- AsyncReportCreateRequest: 비동기 제보 등록 요청 DTO 추가
- AsyncReportService: 비동기 제보 등록/조회 및 AI 검증 요청 발행 로직 추가
- AsyncReportController: 비동기 제보글 등록/조회 API 엔드포인트 추가
- Report: AI 검증 전 tag 미설정을 허용하도록 수정 및 updateTag 메서드 추가
- AiVerificationCompletedEvent: AI 검증 결과 수신용 Kafka 이벤트 정의
- AiVerificationEventListener: AI 검증 결과 수신 후 제보 상태/태그 반영 처리 추가
- ReportQueryRepositoryImpl: 제보글이 APPROVED 상태인 경우만 조회/검색되도록 조건 변경
- QueueFullException: 다량의 요청을 동기식으로 처리 시 처리율 초과 예외 처리 코드 추가

## 🔧 점검 내용

- 관리자가 유의해서 확인해야할 내용이
- 있다면 적어주세요

## ➕ 이슈 링크

- [#31]